### PR TITLE
Move analysis utils under main

### DIFF
--- a/D2T/bart_score.py
+++ b/D2T/bart_score.py
@@ -1,4 +1,3 @@
-# %%
 import torch
 import torch.nn as nn
 import traceback

--- a/SUM/bart_score.py
+++ b/SUM/bart_score.py
@@ -1,4 +1,3 @@
-# %%
 import torch
 import torch.nn as nn
 import traceback

--- a/WMT/bart_score.py
+++ b/WMT/bart_score.py
@@ -1,4 +1,3 @@
-# %%
 import torch
 import torch.nn as nn
 import traceback

--- a/bart_score/analysis.py
+++ b/bart_score/analysis.py
@@ -1,5 +1,4 @@
-# %%
-from utils import *
+from bart_score.utils import *
 from copy import deepcopy
 from tqdm import trange
 from tqdm import tqdm

--- a/bart_score/utils.py
+++ b/bart_score/utils.py
@@ -1,4 +1,3 @@
-# %%
 import pickle
 import jsonlines
 import nltk

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,11 @@ setuptools.setup(
         "torch>=1.6.0",
         "transformers>=4.6.1",
         "pytorch_pretrained_bert>=0.6.2",
+        "nltk>=3.7.0",
         "jsonlines>=3.0.0",
         "mosestokenizer>=1.2.1",
         "pyrouge>=0.1.3",
         "bert-score>=0.3.11",
+        "tabulate>=0.8.10",
     ],
 )


### PR DESCRIPTION
# Overview

Moves the `analysis.py` and `utils.py` modules under the main package (`bart_score`) so they can be imported as follows:

```python
from bart_score import utils
from bart_score.analysis import SUMStat
```

## Other changes

- delete all instances of the IntelliSense comment `"#%%"`
- add missing dependencies (`nltk` and `tabulate`).