### PR TITLE
Add mean and max aggregation

### DIFF
--- a/SUM/score.py
+++ b/SUM/score.py
@@ -255,25 +255,33 @@ class Scorer:
                                 'rougel_f_hypo_ref': rougel_hypo_ref_scores[counter][2],
                             })
                         else:
+                            rouge1_hypo_ref_scores_mean = np.mean(rouge1_hypo_ref_scores, axis=0)
+                            rouge2_hypo_ref_scores_mean = np.mean(rouge2_hypo_ref_scores, axis=0)
+                            rougel_hypo_ref_scores_mean = np.mean(rougel_hypo_ref_scores, axis=0)
+
+                            rouge1_hypo_ref_scores_max = np.max(rouge1_hypo_ref_scores, axis=0)
+                            rouge2_hypo_ref_scores_max = np.max(rouge2_hypo_ref_scores, axis=0)
+                            rougel_hypo_ref_scores_max = np.max(rougel_hypo_ref_scores, axis=0)
+                            
                             self.data[doc_id]['sys_summs'][sys_name]['scores'].update({
-                                'rouge1_r_hypo_ref_mean': np.mean(rouge1_hypo_ref_scores, axis=0)[counter][0],
-                                'rouge1_p_hypo_ref_mean': np.mean(rouge1_hypo_ref_scores, axis=0)[counter][1],
-                                'rouge1_f_hypo_ref_mean': np.mean(rouge1_hypo_ref_scores, axis=0)[counter][2],
-                                'rouge2_r_hypo_ref_mean': np.mean(rouge2_hypo_ref_scores, axis=0)[counter][0],
-                                'rouge2_p_hypo_ref_mean': np.mean(rouge2_hypo_ref_scores, axis=0)[counter][1],
-                                'rouge2_f_hypo_ref_mean': np.mean(rouge2_hypo_ref_scores, axis=0)[counter][2],
-                                'rougel_r_hypo_ref_mean': np.mean(rougel_hypo_ref_scores, axis=0)[counter][0],
-                                'rougel_p_hypo_ref_mean': np.mean(rougel_hypo_ref_scores, axis=0)[counter][1],
-                                'rougel_f_hypo_ref_mean': np.mean(rougel_hypo_ref_scores, axis=0)[counter][2],
-                                'rouge1_r_hypo_ref_max': np.max(rouge1_hypo_ref_scores, axis=0)[counter][0],
-                                'rouge1_p_hypo_ref_max': np.max(rouge1_hypo_ref_scores, axis=0)[counter][1],
-                                'rouge1_f_hypo_ref_max': np.max(rouge1_hypo_ref_scores, axis=0)[counter][2],
-                                'rouge2_r_hypo_ref_max': np.max(rouge2_hypo_ref_scores, axis=0)[counter][0],
-                                'rouge2_p_hypo_ref_max': np.max(rouge2_hypo_ref_scores, axis=0)[counter][1],
-                                'rouge2_f_hypo_ref_max': np.max(rouge2_hypo_ref_scores, axis=0)[counter][2],
-                                'rougel_r_hypo_ref_max': np.max(rougel_hypo_ref_scores, axis=0)[counter][0],
-                                'rougel_p_hypo_ref_max': np.max(rougel_hypo_ref_scores, axis=0)[counter][1],
-                                'rougel_f_hypo_ref_max': np.max(rougel_hypo_ref_scores, axis=0)[counter][2],
+                                'rouge1_r_hypo_ref_mean': rouge1_hypo_ref_scores_mean[counter][0],
+                                'rouge1_p_hypo_ref_mean': rouge1_hypo_ref_scores_mean[counter][1],
+                                'rouge1_f_hypo_ref_mean': rouge1_hypo_ref_scores_mean[counter][2],
+                                'rouge2_r_hypo_ref_mean': rouge2_hypo_ref_scores_mean[counter][0],
+                                'rouge2_p_hypo_ref_mean': rouge2_hypo_ref_scores_mean[counter][1],
+                                'rouge2_f_hypo_ref_mean': rouge2_hypo_ref_scores_mean[counter][2],
+                                'rougel_r_hypo_ref_mean': rougel_hypo_ref_scores_mean[counter][0],
+                                'rougel_p_hypo_ref_mean': rougel_hypo_ref_scores_mean[counter][1],
+                                'rougel_f_hypo_ref_mean': rougel_hypo_ref_scores_mean[counter][2],
+                                'rouge1_r_hypo_ref_max': rouge1_hypo_ref_scores_max[counter][0],
+                                'rouge1_p_hypo_ref_max': rouge1_hypo_ref_scores_max[counter][1],
+                                'rouge1_f_hypo_ref_max': rouge1_hypo_ref_scores_max[counter][2],
+                                'rouge2_r_hypo_ref_max': rouge2_hypo_ref_scores_max[counter][0],
+                                'rouge2_p_hypo_ref_max': rouge2_hypo_ref_scores_max[counter][1],
+                                'rouge2_f_hypo_ref_max': rouge2_hypo_ref_scores_max[counter][2],
+                                'rougel_r_hypo_ref_max': rougel_hypo_ref_scores_max[counter][0],
+                                'rougel_p_hypo_ref_max': rougel_hypo_ref_scores_max[counter][1],
+                                'rougel_f_hypo_ref_max': rougel_hypo_ref_scores_max[counter][2],
                             })
                         counter += 1
                 enablePrint()

--- a/SUM/score.py
+++ b/SUM/score.py
@@ -166,7 +166,6 @@ class Scorer:
                                 "mover_score_mean": np.mean(scores, axis=0)[counter],
                                 "mover_score_max": np.max(scores, axis=0)[counter],
                             })
-                        self.data[doc_id]['sys_summs'][sys_name]['scores']['mover_score'] = scores[counter]
                         counter += 1
                 print(f'Finished calculating MoverScore, time passed {time.time() - start}s.')
 

--- a/SUM/score.py
+++ b/SUM/score.py
@@ -228,22 +228,10 @@ class Scorer:
                             rouge1_hypo_ref_scores.append(r1)
                             rouge2_hypo_ref_scores.append(r2)
                             rougel_hypo_ref_scores.append(rl)
-                        rouge1_hypo_ref_scores = np.mean(rouge1_hypo_ref_scores, axis=0)
-                        rouge2_hypo_ref_scores = np.mean(rouge2_hypo_ref_scores, axis=0)
-                        rougel_hypo_ref_scores = np.mean(rougel_hypo_ref_scores, axis=0)
 
                     counter = 0
                     for doc_id in self.data:
                         self.data[doc_id]['sys_summs'][sys_name]['scores'].update({
-                            'rouge1_r_hypo_ref': rouge1_hypo_ref_scores[counter][0],
-                            'rouge1_p_hypo_ref': rouge1_hypo_ref_scores[counter][1],
-                            'rouge1_f_hypo_ref': rouge1_hypo_ref_scores[counter][2],
-                            'rouge2_r_hypo_ref': rouge2_hypo_ref_scores[counter][0],
-                            'rouge2_p_hypo_ref': rouge2_hypo_ref_scores[counter][1],
-                            'rouge2_f_hypo_ref': rouge2_hypo_ref_scores[counter][2],
-                            'rougel_r_hypo_ref': rougel_hypo_ref_scores[counter][0],
-                            'rougel_p_hypo_ref': rougel_hypo_ref_scores[counter][1],
-                            'rougel_f_hypo_ref': rougel_hypo_ref_scores[counter][2],
                             'rouge1_r_src_hypo': rouge1_src_hypo_scores[counter][0],
                             'rouge1_p_src_hypo': rouge1_src_hypo_scores[counter][1],
                             'rouge1_f_src_hypo': rouge1_src_hypo_scores[counter][2],
@@ -254,6 +242,39 @@ class Scorer:
                             'rougel_p_src_hypo': rougel_src_hypo_scores[counter][1],
                             'rougel_f_src_hypo': rougel_src_hypo_scores[counter][2]
                         })
+                        if not self.multi_ref:
+                            self.data[doc_id]['sys_summs'][sys_name]['scores'].update({
+                                'rouge1_r_hypo_ref': rouge1_hypo_ref_scores[counter][0],
+                                'rouge1_p_hypo_ref': rouge1_hypo_ref_scores[counter][1],
+                                'rouge1_f_hypo_ref': rouge1_hypo_ref_scores[counter][2],
+                                'rouge2_r_hypo_ref': rouge2_hypo_ref_scores[counter][0],
+                                'rouge2_p_hypo_ref': rouge2_hypo_ref_scores[counter][1],
+                                'rouge2_f_hypo_ref': rouge2_hypo_ref_scores[counter][2],
+                                'rougel_r_hypo_ref': rougel_hypo_ref_scores[counter][0],
+                                'rougel_p_hypo_ref': rougel_hypo_ref_scores[counter][1],
+                                'rougel_f_hypo_ref': rougel_hypo_ref_scores[counter][2],
+                            })
+                        else:
+                            self.data[doc_id]['sys_summs'][sys_name]['scores'].update({
+                                'rouge1_r_hypo_ref_mean': np.mean(rouge1_hypo_ref_scores, axis=0)[counter][0],
+                                'rouge1_p_hypo_ref_mean': np.mean(rouge1_hypo_ref_scores, axis=0)[counter][1],
+                                'rouge1_f_hypo_ref_mean': np.mean(rouge1_hypo_ref_scores, axis=0)[counter][2],
+                                'rouge2_r_hypo_ref_mean': np.mean(rouge2_hypo_ref_scores, axis=0)[counter][0],
+                                'rouge2_p_hypo_ref_mean': np.mean(rouge2_hypo_ref_scores, axis=0)[counter][1],
+                                'rouge2_f_hypo_ref_mean': np.mean(rouge2_hypo_ref_scores, axis=0)[counter][2],
+                                'rougel_r_hypo_ref_mean': np.mean(rougel_hypo_ref_scores, axis=0)[counter][0],
+                                'rougel_p_hypo_ref_mean': np.mean(rougel_hypo_ref_scores, axis=0)[counter][1],
+                                'rougel_f_hypo_ref_mean': np.mean(rougel_hypo_ref_scores, axis=0)[counter][2],
+                                'rouge1_r_hypo_ref_max': np.max(rouge1_hypo_ref_scores, axis=0)[counter][0],
+                                'rouge1_p_hypo_ref_max': np.max(rouge1_hypo_ref_scores, axis=0)[counter][1],
+                                'rouge1_f_hypo_ref_max': np.max(rouge1_hypo_ref_scores, axis=0)[counter][2],
+                                'rouge2_r_hypo_ref_max': np.max(rouge2_hypo_ref_scores, axis=0)[counter][0],
+                                'rouge2_p_hypo_ref_max': np.max(rouge2_hypo_ref_scores, axis=0)[counter][1],
+                                'rouge2_f_hypo_ref_max': np.max(rouge2_hypo_ref_scores, axis=0)[counter][2],
+                                'rougel_r_hypo_ref_max': np.max(rougel_hypo_ref_scores, axis=0)[counter][0],
+                                'rougel_p_hypo_ref_max': np.max(rougel_hypo_ref_scores, axis=0)[counter][1],
+                                'rougel_f_hypo_ref_max': np.max(rougel_hypo_ref_scores, axis=0)[counter][2],
+                            })
                         counter += 1
                 enablePrint()
                 os.system('rm -rf hypo.txt ref.txt src.txt')


### PR DESCRIPTION
# Overview

Add mean and max aggregation in the multi-reference setting.

## TODO

- [X] BERTScore
- [x] MoverScore
- [X] ROUGE
- [ ] PRISM
- [x] BARTScore
- [x] Re-create scores from paper with this code


## Other changes

- Print out `bert_score` hash code in script
- Use `tqdm` progress bars for all metrics
- Add (src, hypo) for MoverScore